### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 name: CI
-permissions:
-  contents: read
 on:
   push: ~
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 name: CI
+permissions:
+  contents: read
 on:
   push: ~
 


### PR DESCRIPTION
Potential fix for [https://github.com/todofixthis/filters/security/code-scanning/5](https://github.com/todofixthis/filters/security/code-scanning/5)

To resolve the issue, add a `permissions` block to the root of the workflow (above the `jobs:` key in `.github/workflows/build.yml`). This will restrict the GITHUB_TOKEN permissions for all jobs in the workflow that do not override them. Since all jobs in this workflow only need read access to the repository (to clone, install code dependencies, and run tests), set `contents: read` as the permission. No existing functionality will be changed by this fix; it simply enforces a safer permissions boundary. No additional libraries or modifications elsewhere are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
